### PR TITLE
Fix: Localize steps label in Goals Screen

### DIFF
--- a/lib/generated/app_localizations.dart
+++ b/lib/generated/app_localizations.dart
@@ -140,6 +140,12 @@ abstract class AppLocalizations {
   /// **'Fat'**
   String get fat;
 
+  /// No description provided for @steps.
+  ///
+  /// In en, this message translates to:
+  /// **'Steps'**
+  String get steps;
+
   /// No description provided for @daily.
   ///
   /// In en, this message translates to:

--- a/lib/generated/app_localizations_de.dart
+++ b/lib/generated/app_localizations_de.dart
@@ -30,6 +30,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fat => 'Fett';
 
   @override
+  String get steps => 'Schritte';
+
+  @override
   String get daily => 'Täglich';
 
   @override

--- a/lib/generated/app_localizations_en.dart
+++ b/lib/generated/app_localizations_en.dart
@@ -30,6 +30,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fat => 'Fat';
 
   @override
+  String get steps => 'Steps';
+
+  @override
   String get daily => 'Daily';
 
   @override

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -7,6 +7,7 @@
   "protein": "Protein",
   "carbs": "Kohlenhydrate",
   "fat": "Fett",
+  "steps": "Schritte",
   "daily": "Täglich",
   "today": "Heute",
   "workoutSection": "Workout-Bereich - noch nicht implementiert",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7,6 +7,7 @@
   "protein": "Protein",
   "carbs": "Carbs",
   "fat": "Fat",
+  "steps": "Steps",
   "daily": "Daily",
   "today": "Today",
   "workoutSection": "Workout section - not yet implemented",

--- a/lib/screens/goals_screen.dart
+++ b/lib/screens/goals_screen.dart
@@ -197,7 +197,7 @@ class _GoalsScreenState extends State<GoalsScreen> {
                     ),
                     _buildSettingsField(
                       controller: _stepsController,
-                      label: 'Steps', // TODO(alpha): localize steps label
+                      label: l10n.steps,
                     ),
                     const SizedBox(height: DesignConstants.spacingXL),
                     _buildSectionTitle(context, l10n.detailedNutrientGoalsCL),


### PR DESCRIPTION
Fix: Localize steps label in Goals Screen

This PR addresses a hygiene issue identified during a repo scan: a `TODO(alpha): localize steps label` in `goals_screen.dart`.

- Added "steps" to `app_en.arb` ("Steps") and `app_de.arb` ("Schritte").
- Replaced the hardcoded string with `l10n.steps` in `lib/screens/goals_screen.dart`.
- Regenerated localization files.
- Verified test suite passes without regressions.

The following candidates are recommended for next small issues:
1. `lib/screens/meals_screen.dart` lines 37 and 52: "TODO: Liste neu laden (später)". We should add list reloading logic after creating/editing a meal to avoid a stale UI list.
2. `lib/screens/goals_screen.dart` line 230: There is a commented out `// KORREKTUR: Der untere Button wurde entfernt` that is essentially a stale comment. We can clean up the dead comments in `_GoalsScreenState.build`.
3. `alle_dateien.txt` lists many `// TODO: Lokalisieren` lines, such as 'Profil bearbeiten' and 'Geburtsdatum wählen', which could be localized similarly to this PR.

---
*PR created automatically by Jules for task [8135540404452577899](https://jules.google.com/task/8135540404452577899) started by @rfivesix*